### PR TITLE
fix(immich): align values with chart 0.13.1 schema

### DIFF
--- a/kubernetes/apps/entertainment/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/immich/app/helmrelease.yaml
@@ -37,9 +37,6 @@ spec:
                   memory: 896Mi
                 limits:
                   memory: 2Gi
-      route:
-        enabled: false
-
     immich:
       # Enable Prometheus metrics collection
       metrics:
@@ -83,7 +80,7 @@ spec:
       persistence:
         cache:
           enabled: true
-          storageClass: longhorn
+          type: persistentVolumeClaim
+          accessMode: ReadWriteOnce
           size: 10Gi
-      route:
-        enabled: false
+          storageClass: longhorn

--- a/templates/config/kubernetes/apps/entertainment/immich/app/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/entertainment/immich/app/helmrelease.yaml.j2
@@ -37,9 +37,6 @@ spec:
                   memory: 896Mi
                 limits:
                   memory: 2Gi
-      route:
-        enabled: false
-
     immich:
       # Enable Prometheus metrics collection
       metrics:
@@ -83,7 +80,7 @@ spec:
       persistence:
         cache:
           enabled: true
-          storageClass: longhorn
+          type: persistentVolumeClaim
+          accessMode: ReadWriteOnce
           size: 10Gi
-      route:
-        enabled: false
+          storageClass: longhorn


### PR DESCRIPTION
## Description

Fixes the immich HelmRelease values to match the chart v0.13.1 schema. The immich chart was updated to v0.13.1 in #266, but the chart's schema validation has since been updated and no longer accepts the current values.

## Changes

- **Remove** `server.route.enabled` and `machine-learning.route.enabled` — `route` is not a valid key in the bjw-s common library schema that the chart uses for validation. External access is handled via the separate `HTTPRoute` resource.
- **Fix** `machine-learning.persistence.cache` — added explicit `type: persistentVolumeClaim` and `accessMode: ReadWriteOnce` which are required by the schema. The previous implicit PVC was missing `accessMode`, causing `helm template` to reject `size` and `storageClass` as invalid properties.

## Why

This is a pre-existing failure causing all flux-local tests to fail on any PR that touches `kubernetes/**`, including renovate PRs like #270.

## Verification

- [x] Flux Local Test should pass after this merge
- [x] `task configure --yes` to regenerate